### PR TITLE
Fix SubRegionSerializer URL

### DIFF
--- a/src/cities_light/contrib/restframework3.py
+++ b/src/cities_light/contrib/restframework3.py
@@ -52,7 +52,7 @@ class SubRegionSerializer(HyperlinkedModelSerializer):
     HyperlinkedModelSerializer for SubRegion.
     """
     url = relations.HyperlinkedIdentityField(
-        view_name='cities-light-api-city-detail')
+        view_name='cities-light-api-subregion-detail')
     country = relations.HyperlinkedRelatedField(
         view_name='cities-light-api-country-detail', read_only=True)
     region = relations.HyperlinkedRelatedField(


### PR DESCRIPTION
There's a typo bug here. SubRegionSerializer uses incorrect url handler for generating its own url.